### PR TITLE
Add various improvements

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,5 +5,6 @@ fixtures:
   forge_modules:
      stdlib: "puppetlabs/stdlib"
      archive: "puppet/archive"
+     apt: "puppetlabs/apt"
      docker: "puppetlabs/docker"
      yumrepo_core: "puppetlabs/yumrepo_core"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+## Contributing
+
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_GEM_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+...or promote reuse of bundled gems across projects by running:
+
+    bundle install --path=~/.bundle
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+    bundle exec metadata_lint
+    bundle exec rubocop
+
+See Travis configuration for all syntax and style tests.
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+To run in parallel:
+
+    bundle exec rake parallel_spec

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This module will install Docker and run Harbor through docker-compose as this is
 
 This will set up and start harbor with the completely default harbor.cfg configuration.
 
-Make sure your target system meets the Harbor prerequisites outlined at https://github.com/goharbor/harbor/blob/master/docs/installation_guide.md#prerequisites-for-the-target-host  
+Make sure your target system meets the Harbor prerequisites outlined at https://github.com/goharbor/harbor/blob/master/docs/installation_guide.md#prerequisites-for-the-target-host
 
 ## Usage
 
@@ -36,8 +36,14 @@ Include usage examples for common use cases in the **Usage** section. Show your 
 
 ## Limitations
 
-TBD.
+This module supports:
+
+    Centos 7.0
+    RedHat 7.0
+    Debian 9.0
+
+For an extensive list of supported operating systems, see [metadata.json](metadata.json).
 
 ## Development
 
-TBD.
+If you would like to contribute to this module, see the guidelines in [CONTRIBUTING.MD](CONTRIBUTING.md).

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,7 @@
 ---
-harbor::version: '1.7.0'
+harbor::version: '1.7.5'
+harbor::release: '1.7.0'
+harbor::checksum: '6da2f6ff3be598b5c657a9b204bda8af'
 harbor::installer: 'offline'
 harbor::with_notary: false
 harbor::with_clair: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,10 @@
 # @note For full configuration parameter documentation, see the {https://github.com/goharbor/harbor/blob/master/docs/installation_guide.md Harbor Installation Guide}.
 #
 # @param version
-#   Specifies the Harbor release version to install. See available releases at {https://github.com/goharbor/harbor/releases Harbor Releases}
+#   Specifies the Harbor version to install. See available releases at {https://github.com/goharbor/harbor/releases Harbor Releases}
+#
+# @param release
+#   Specifies the Harbor release for the download URL.
 #
 # @param installer
 #   Specifies which installer type to use. Note that not every release has both installer types available.
@@ -158,7 +161,9 @@
 #
 class harbor (
   Pattern[/\d+\.\d+\.\d+.*/] $version,
+  Pattern[/\d+\.\d+\.\d+.*/] $release,
   Enum['offline','online'] $installer,
+  String  $checksum,
   Boolean $with_notary,
   Boolean $with_clair,
   Boolean $with_chartmuseum,
@@ -227,7 +232,7 @@ class harbor (
   Variant[Stdlib::Absolutepath,String[0,0]] $registry_custom_ca_bundle,
   Variant[Boolean,String[0,0]] $reload_config,
   String $skip_reload_env_pattern,
-  Stdlib::Httpurl $download_source = "https://storage.googleapis.com/harbor-releases/release-${version}/harbor-${installer}-installer-v${version}.tgz",
+  Stdlib::Httpurl $download_source = "https://storage.googleapis.com/harbor-releases/release-${release}/harbor-${installer}-installer-v${version}.tgz",
 ){
 
   include 'docker'
@@ -245,6 +250,7 @@ class harbor (
   class { 'harbor::install':
     installer       => $installer,
     version         => $version,
+    checksum        => $checksum,
     download_source => $download_source,
     proxy_server    => $_proxy_server,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,44 +18,66 @@
 #
 # @param with_notary
 #   Specifies whether to include Notary functionality in the deployment.
+#   Defaults to false
 #
 # @param with_clair
 #   Specifies whether to include Clair functionality in the deployment.
+#   Defaults to false
 #
 # @param with_chartmuseum
 #   Specifies whether to include Helm Chart repository functionality in the deployment.
+#   Defaults to false
 #
 # @param harbor_ha
 #   Specifies whether to include high availability functionality in the deployment.
+#   Defaults to false
 #
 # @param download_source
 #   Specifies download location for the Harbor installation tar file.
 #
 # @param hostname
+#   The target host's hostname, which is used to access the Portal and the registry service.
+#   It should be the IP address or the fully qualified domain name (FQDN) of your target machine.
+#   Defaults to facts.fqdn
 #
 # @param ui_url_protocol
+#   http or https.
+#   Defaults to http
 #
 # @param max_job_workers
+#   The maximum number of replication workers in job service
+#   Defaults to 10
 #
 # @param customize_crt
+#   When this attribute is on, the prepare script creates private key and root certificate
+#   for the generation/verification of the registry's token.
+#   Defaults to on
 #
 # @param ssl_cert
+#   The path of SSL certificate,
 #
 # @param ssl_cert_key
+#   The path of SSL key
 #
 # @param secretkey_path
+#   The path of key for encrypt or decrypt the password of a remote registry in a replication policy.
 #
 # @param admiral_url
 #
 # @param log_rotate_count
+#  Defaults to 50
 #
 # @param log_rotate_size
+#  Defaults to 200M
 #
 # @param http_proxy
+#  Defaults to None
 #
 # @param https_proxy
+#  Defaults to None
 #
 # @param no_proxy
+#  Defaults to '127.0.0.1,localhost,ui,registry'
 #
 # @param email_identity
 #
@@ -74,6 +96,7 @@
 # @param email_insecure
 #
 # @param harbor_admin_password
+#   Defaults to Harbor12345
 #
 # @param auth_mode
 #
@@ -112,30 +135,42 @@
 # @param project_creation_restriction
 #
 # @param db_host
+#  Defaults to postgresql
 #
 # @param db_password
+#   Defaults to root123
 #
 # @param db_port
+#   Defaults to 5432
 #
 # @param db_user
+#   Defaults to postgres
 #
 # @param redis_host
+#   Defaults to redis
 #
 # @param redis_port
+#   Defaults to 6379
 #
 # @param redis_password
+#   Defaults to None
 #
 # @param redis_db_index
 #
 # @param clair_db_host
+#   Defaults to postgresql
 #
 # @param clair_db_password
+#   Defaults to root123
 #
 # @param clair_db_port
+#   Defaults to 5432
 #
 # @param clair_db_username
+#   Defaults to postgres
 #
 # @param clair_db
+#   Defaults to postgres
 #
 # @param clair_updaters_interval
 #

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,6 +2,7 @@
 class harbor::install (
   $installer,
   $version,
+  $checksum,
   $download_source,
   $proxy_server = undef,
 ){
@@ -16,14 +17,16 @@ class harbor::install (
   }
 
   archive { "/tmp/harbor-${installer}-installer-v${version}.tgz":
-    ensure       => present,
-    extract      => true,
-    extract_path => "/opt/harbor-v${version}",
-    source       => $download_source,
-    creates      => "/opt/harbor-v${version}/harbor",
-    cleanup      => true,
-    proxy_server => $proxy_server,
-    require      => File["/opt/harbor-v${version}"],
+    ensure        => present,
+    extract       => true,
+    extract_path  => "/opt/harbor-v${version}",
+    source        => $download_source,
+    checksum      => $checksum,
+    checksum_type => 'md5',
+    creates       => "/opt/harbor-v${version}/harbor",
+    cleanup       => true,
+    proxy_server  => $proxy_server,
+    require       => File["/opt/harbor-v${version}"],
   }
 
   file { '/opt/harbor':

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -41,7 +41,8 @@ class harbor::service (
   }
 
   exec { 'harbor_systemd_daemon-reload':
-    command     => '/usr/bin/systemctl daemon-reload',
+    path        => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
+    command     => 'systemctl daemon-reload > /dev/null',
     refreshonly => true,
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 5.0.0"
+      "version_requirement": ">= 4.25.0 < 6.0.0"
     },
     {
       "name": "puppet/archive",

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,10 @@
     {
       "name": "puppetlabs/docker",
       "version_requirement": ">= 3.0.0 < 4.0.0"
+    },
+    {
+      "name": "puppetlabs/apt",
+      "version_requirement": ">= 4.4.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -44,6 +48,12 @@
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
         "7"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "9"
       ]
     }
   ],

--- a/spec/classes/harbor_spec.rb
+++ b/spec/classes/harbor_spec.rb
@@ -15,11 +15,11 @@ describe 'harbor' do
       describe 'harbor::install' do
         context 'with init default params' do
           it do
-            is_expected.to contain_archive('/tmp/harbor-offline-installer-v1.7.0.tgz').with(
-              'source' => 'https://storage.googleapis.com/harbor-releases/release-1.7.0/harbor-offline-installer-v1.7.0.tgz',
+            is_expected.to contain_archive('/tmp/harbor-offline-installer-v1.7.5.tgz').with(
+              'source' => 'https://storage.googleapis.com/harbor-releases/release-1.7.0/harbor-offline-installer-v1.7.5.tgz',
             )
           end
-          it { is_expected.to contain_file('/opt/harbor-v1.7.0') }
+          it { is_expected.to contain_file('/opt/harbor-v1.7.5') }
           it { is_expected.to contain_file('/opt/harbor') }
           it { is_expected.to contain_docker__image('goharbor/harbor-ui') }
         end


### PR DESCRIPTION
Hello, 

I've added some stuff:

- Update metadata to ensure puppetlabs-stdlib 5.* is a dependency

The setting was < 5.0.0, but the stdlib is at 5.2.0 currently. Now the warning is gone and the installation runs without issues.

- Add checksum parameter for puppet-archive

This ensures the integrity of the package and addresses malicious tampering. I also updated to 1.7.5, which required an extra parameter (release), since the download URL is:

https://storage.googleapis.com/harbor-releases/release-1.7.0/harbor-offline-installer-v1.7.5.tgz

- Add support for Debian 9 Stretch

By adding puppetlabs-apt and updating the exec resource. Tested that in Vagrant, works like a charm :whale: 

- Add some more documentation to the parameters; Update README and add CONTRIBUTING.md

You can drop these is you want, just thought it might be nice to have.

Cheers, 
Markus