### PR TITLE
Avoid calling map() on nil in harbor_project's provider

### DIFF
--- a/lib/puppet/provider/harbor_project/swagger.rb
+++ b/lib/puppet/provider/harbor_project/swagger.rb
@@ -64,23 +64,10 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
-    end
-
-    api_instance = SwaggerClient::ProductsApi.new
-    api_instance
-  end
-
-  def do_login
-    require 'yaml'
-    require 'harbor_swagger_client'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-
-    SwaggerClient.configure do |config|
-      config.username = my_config['username']
-      config.password = my_config['password']
-      config.scheme = my_config['scheme']
-      config.verify_ssl = my_config['verify_ssl']
-      config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new
@@ -88,7 +75,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def exists?
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: resource[:name],
@@ -116,7 +103,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def create
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     np = SwaggerClient::ProjectReq.new(project_name: resource[:name], metadata: { public: resource[:public] })
 
@@ -140,7 +127,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def public=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_project_id_by_name(resource[:name])
 
@@ -158,7 +145,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def members
-    api_instance = do_login
+    api_instance = self.class.do_login
     id = get_project_id_by_name(resource[:name])
     members = api_instance.projects_project_id_members_get(id)
     member_arry = []
@@ -185,7 +172,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def member_groups
-    api_instance = do_login
+    api_instance = self.class.do_login
     id = get_project_id_by_name(resource[:name])
     members = api_instance.projects_project_id_members_get(id)
     member_arry = []
@@ -213,7 +200,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
 
 
   def get_project_id_by_name(project_name)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: project_name,
@@ -225,7 +212,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def get_current_project_members(id)
-    api_instance = do_login
+    api_instance = self.class.do_login
     members = api_instance.projects_project_id_members_get(id)
     member_arry = []
     members.each do |member|
@@ -238,7 +225,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def get_current_project_member_groups(id)
-    api_instance = do_login
+    api_instance = self.class.do_login
     members = api_instance.projects_project_id_members_get(id)
     member_arry = []
     members.each do |member|
@@ -251,7 +238,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def add_members_to_project(id, members)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     members.sort!
     members.each do |member|
@@ -265,7 +252,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def add_member_groups_to_project(id, member_groups)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     member_groups.sort!
     member_groups.each do |group|
@@ -280,7 +267,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def get_usergroup_id_by_name(group)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     ug = api_instance.usergroups_get()
     group.downcase!
@@ -289,7 +276,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def remove_members_from_project(id, members_to_delete)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     members_to_delete.sort!
     members_to_delete.each do |member|
@@ -299,7 +286,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def remove_member_groups_from_project(id, member_groups_to_delete)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     member_groups_to_delete.sort!
     member_groups_to_delete.each do |member_group|
@@ -309,7 +296,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def get_project_member_id_by_name(id, member)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       entityname: member,
@@ -320,7 +307,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def destroy
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: resource[:name],

--- a/lib/puppet/provider/harbor_registry/swagger.rb
+++ b/lib/puppet/provider/harbor_registry/swagger.rb
@@ -42,23 +42,10 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
-    end
-
-    api_instance = SwaggerClient::ProductsApi.new
-    api_instance
-  end
-
-  def do_login
-    require 'yaml'
-    require 'harbor_swagger_client'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-
-    SwaggerClient.configure do |config|
-      config.username = my_config['username']
-      config.password = my_config['password']
-      config.scheme = my_config['scheme']
-      config.verify_ssl = my_config['verify_ssl']
-      config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new
@@ -66,7 +53,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def exists?
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: resource[:name],
@@ -86,7 +73,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def create
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     if resource[:insecure]
       insecure_bool = cast_to_bool(resource[:insecure].to_s)
@@ -113,7 +100,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def set_registry_credential(id) # rubocop:disable Style/AccessorMethodName
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     repo_target = SwaggerClient::PutRegistry.new(access_key: resource[:access_key], access_secret: resource[:access_secret])
 
@@ -130,7 +117,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def get_registry_id_by_name(registry_name)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: registry_name,
@@ -146,7 +133,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def description=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_registry_id_by_name(resource[:name])
 
@@ -160,7 +147,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def insecure=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_registry_id_by_name(resource[:name])
 
@@ -176,7 +163,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def url=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_registry_id_by_name(resource[:name])
 
@@ -190,7 +177,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def destroy
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     registry_id = get_registry_id_by_name(resource[:name])
 

--- a/lib/puppet/provider/harbor_replication_policy/swagger.rb
+++ b/lib/puppet/provider/harbor_replication_policy/swagger.rb
@@ -61,23 +61,10 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
-    end
-
-    api_instance = SwaggerClient::ProductsApi.new
-    api_instance
-  end
-
-  def do_login
-    require 'yaml'
-    require 'harbor_swagger_client'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-
-    SwaggerClient.configure do |config|
-      config.username = my_config['username']
-      config.password = my_config['password']
-      config.scheme = my_config['scheme']
-      config.verify_ssl = my_config['verify_ssl']
-      config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new
@@ -85,7 +72,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def get_replication_policy_id_by_name(replication_policy_name)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: replication_policy_name,
@@ -101,7 +88,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def exists?
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: resource[:name],
@@ -126,7 +113,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def get_registry_id_by_name(registry_name)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: registry_name,
@@ -142,7 +129,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def get_registry_info_by_name(registry_name)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: registry_name,
@@ -172,7 +159,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def create
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     if resource[:deletion]
       deletion_bool = cast_to_bool(resource[:deletion].to_s)
@@ -224,7 +211,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def update_replication_policy_param(resource)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     if resource[:deletion]
       deletion_bool = cast_to_bool(resource[:deletion].to_s)
@@ -304,7 +291,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def destroy
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     replication_policy_id = get_replication_policy_id_by_name(resource[:name])
 

--- a/lib/puppet/provider/harbor_system_label/swagger.rb
+++ b/lib/puppet/provider/harbor_system_label/swagger.rb
@@ -39,23 +39,10 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
-    end
-
-    api_instance = SwaggerClient::ProductsApi.new
-    api_instance
-  end
-
-  def do_login
-    require 'yaml'
-    require 'harbor_swagger_client'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-
-    SwaggerClient.configure do |config|
-      config.username = my_config['username']
-      config.password = my_config['password']
-      config.scheme = my_config['scheme']
-      config.verify_ssl = my_config['verify_ssl']
-      config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new
@@ -63,7 +50,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def get_label_id_by_name(label_name)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: label_name,
@@ -79,7 +66,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def name=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_label_id_by_name(resource[:name])
 
@@ -97,7 +84,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def description=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_label_id_by_name(resource[:name])
 
@@ -115,7 +102,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def color=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_label_id_by_name(resource[:name])
 
@@ -133,7 +120,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def exists?
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: resource[:name],
@@ -153,7 +140,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def create
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     nl = SwaggerClient::Label.new(name: resource[:name], description: resource[:description], color: resource[:color], scope: 'g')
 
@@ -165,7 +152,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def destroy
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     label_id = get_label_id_by_name(resource[:name])
 

--- a/lib/puppet/provider/harbor_user_settings/swagger.rb
+++ b/lib/puppet/provider/harbor_user_settings/swagger.rb
@@ -15,6 +15,10 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new

--- a/lib/puppet/type/harbor_registry.rb
+++ b/lib/puppet/type/harbor_registry.rb
@@ -31,8 +31,8 @@ DESC
 
   newparam(:set_credential) do
     desc 'Whether to set the credential for the registry'
-    defaultto :false
     newvalues(:true, :false)
+    defaultto :false
   end
 
   newparam(:access_key) do
@@ -45,7 +45,12 @@ DESC
 
   newproperty(:insecure) do
     desc 'Whether or not the certificate will be verified when Harbor tries to access the server'
-    defaultto :false
     newvalues(:true, :false)
+    defaultto :false
+  end
+
+  newparam(:type) do
+    desc 'Type of the registry, e.g. "harbor", "gitlab".'
+    defaultto 'harbor'
   end
 end

--- a/spec/unit/puppet/provider/harbor_project/swagger_spec.rb
+++ b/spec/unit/puppet/provider/harbor_project/swagger_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:harbor_project).provider(:swagger) do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      describe 'when validating class interface' do
+        [ :instances, :prefetch ].each do |method|
+          it "should have a method \"#{method}\"" do
+            expect(described_class).to respond_to :method
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/provider/harbor_registry/swagger_spec.rb
+++ b/spec/unit/puppet/provider/harbor_registry/swagger_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:harbor_registry).provider(:swagger) do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      describe 'when validating class interface' do
+        [ :instances, :prefetch ].each do |method|
+          it "should have a method \"#{method}\"" do
+            expect(described_class).to respond_to :method
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/harbor_project_spec.rb
+++ b/spec/unit/puppet/type/harbor_project_spec.rb
@@ -9,12 +9,12 @@ describe Puppet::Type.type(:harbor_project) do
 
       describe 'when validating attributes' do
         [ :name ].each do |param|
-          it "should have a parameter \"#{param}\"" do
+          it "should have a parameter '#{param}'" do
             expect(described_class.attrtype(param)).to eq(:param)
           end
         end
-        [ :public, :members, :member_groups ].each do |prop|
-          it "should have a property \"#{prop}\"" do
+        [ :ensure, :public, :members, :member_groups ].each do |prop|
+          it "should have a property '#{prop}'" do
             expect(described_class.attrtype(prop)).to eq(:property)
           end
         end
@@ -29,7 +29,7 @@ describe Puppet::Type.type(:harbor_project) do
       describe 'when validating attribute values' do
         describe 'ensure' do
           [ :present, :absent ].each do |value|
-            it "should support \"#{value}\" as a value to \"ensure\"" do
+            it "should support value '#{value}'" do
               expect { described_class.new({
                 :name   => 'the_project',
                 :ensure => value,
@@ -47,7 +47,7 @@ describe Puppet::Type.type(:harbor_project) do
 
         describe "public" do
           [ 'false', 'true' ].each do |value|
-            it "should support '#{value}' as a value for \"public\"" do
+            it "should support value '#{value}'" do
               expect { described_class.new({
                 :name   => 'the_project',
                 :public => value,

--- a/spec/unit/puppet/type/harbor_project_spec.rb
+++ b/spec/unit/puppet/type/harbor_project_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:harbor_project) do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      describe 'when validating attributes' do
+        [ :name ].each do |param|
+          it "should have a parameter \"#{param}\"" do
+            expect(described_class.attrtype(param)).to eq(:param)
+          end
+        end
+        [ :public, :members, :member_groups ].each do |prop|
+          it "should have a property \"#{prop}\"" do
+            expect(described_class.attrtype(prop)).to eq(:property)
+          end
+        end
+      end
+
+      describe "namevar validation" do
+        it "should have :name as its namevar" do
+          expect(described_class.key_attributes).to eq([:name])
+        end
+      end
+
+      describe 'when validating attribute values' do
+        describe 'ensure' do
+          [ :present, :absent ].each do |value|
+            it "should support \"#{value}\" as a value to \"ensure\"" do
+              expect { described_class.new({
+                :name   => 'the_project',
+                :ensure => value,
+              })}.to_not raise_error
+            end
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :name   => 'the_project',
+              :ensure => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+        end
+
+        describe "public" do
+          [ 'false', 'true' ].each do |value|
+            it "should support '#{value}' as a value for \"public\"" do
+              expect { described_class.new({
+                :name   => 'the_project',
+                :public => value,
+              }) }.to_not raise_error
+            end
+          end
+
+          it "should default to false" do
+            expect(described_class.new({
+              :name => 'the_project'
+            })[:public]).to eq :false
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :name   => 'the_project',
+              :public => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/harbor_registry_spec.rb
+++ b/spec/unit/puppet/type/harbor_registry_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:harbor_registry) do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      describe 'when validating attributes' do
+        [ :name, :set_credential, :access_key, :access_secret, :type ].each do |param|
+          it "should have a parameter '#{param}'" do
+            expect(described_class.attrtype(param)).to eq(:param)
+          end
+        end
+        [ :ensure, :description, :url, :insecure ].each do |prop|
+          it "should have a property '#{prop}'" do
+            expect(described_class.attrtype(prop)).to eq(:property)
+          end
+        end
+      end
+
+      describe "namevar validation" do
+        it "should have :name as its namevar" do
+          expect(described_class.key_attributes).to eq([:name])
+        end
+      end
+
+      describe 'when validating attribute values' do
+        describe 'ensure' do
+          [ :present, :absent ].each do |value|
+            it "should support value '#{value}'" do
+              expect { described_class.new({
+                :name   => 'the_name',
+                :ensure => value,
+              })}.to_not raise_error
+            end
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :name   => 'the_name',
+              :ensure => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+        end
+
+        describe "set_credential" do
+          [ 'false', 'true' ].each do |value|
+            it "should support value '#{value}'" do
+              expect { described_class.new({
+                :name           => 'the_name',
+                :set_credential => value,
+              }) }.to_not raise_error
+            end
+          end
+
+          it "should default to false" do
+            expect(described_class.new({
+              :name => 'the_name'
+            })[:set_credential]).to eq :false
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :name           => 'the_name',
+              :set_credential => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+        end
+
+        describe "insecure" do
+          [ 'false', 'true' ].each do |value|
+            it "should support value '#{value}'" do
+              expect { described_class.new({
+                :name           => 'the_name',
+                :insecure => value,
+              }) }.to_not raise_error
+            end
+          end
+
+          it "should default to false" do
+            expect(described_class.new({
+              :name => 'the_name'
+            })[:insecure]).to eq :false
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :name     => 'the_name',
+              :insecure => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+        end
+
+        describe "type" do
+          it "should default to 'harbor'" do
+            expect(described_class.new({
+              :name => 'the_name'
+            })[:type]).to eq 'harbor'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolved issue in self.instances() when calling map() on nil object which is returned by api_instance.projects_get() if there are no registries.
In general split much code into small methods in order to allow reuse and remove duplicated code, and improve readability and understanding.

Additionally:
- Added filtering of returned projects by api_instance.projects_get() for a for given 'name'. This is required because api_instance.projects_get() returns also projects which contain the given name partly, e.g. 'demo push' will also be returned when asking for 'demo' beside.
- Renamed variables and methods in order to distinguish if SwaggerClient's ProjectMemberEntity objects or simple member/member_group names are used.
- Slightly reworked 'describe' texts in tests.

Note that this branch bases on branch of [pull request #26](https://github.com/walkamongus/puppet-harbor/pull/26).