### PR TITLE
API stores and returns these as lower.  This fixes puppet 'corrective…

### DIFF
--- a/lib/puppet/type/harbor_project.rb
+++ b/lib/puppet/type/harbor_project.rb
@@ -34,6 +34,7 @@ DESC
 
   newproperty(:member_groups, array_matching: :all) do
     desc 'An array of member groups for the project'
+    munge { |value| value.downcase }
     def insync?(is)
       is.sort == should.sort
     end


### PR DESCRIPTION
…' changes for member groups case.