### PR TITLE
Resolve issues during upgrade with backup

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -19,7 +19,7 @@ class harbor::backup (
     command   => "tar -cvzf ${backup_directory}/harbor_v${version}_db_backup.tar.gz ${data_volume}/database",
     creates   => "${backup_directory}/harbor_v${version}_db_backup.tar.gz",
     logoutput => true,
-    requires  => Exec['stop_harbor'],
+    require   => Exec['stop_harbor'],
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -263,7 +263,7 @@ class harbor (
         class { 'harbor::backup':
           version        => $_running_version,
           data_volume    => $data_volume,
-          back_directory => $backup_directory,
+          backup_directory => $backup_directory,
           before         => Class['harbor::install'],
         }
         contain 'harbor::backup'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -42,6 +42,7 @@ class harbor::install (
     # prevent the docker::image resource from executing each puppet run.
     # goharbor/harbor-log exists in both the 1.6.x and 1.7.x releases.
     docker::image { 'goharbor/harbor-log':
+      image_tag  => "v${version}",
       docker_tar => '/opt/harbor/harbor*.tar.gz',
       subscribe  => File['/opt/harbor'],
     }

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -29,6 +29,7 @@ class harbor::prepare (
   exec { 'prepare_harbor':
     cwd         => '/opt/harbor',
     command     => "/opt/harbor/prepare ${opts}",
+    timeout     => 0,
     logoutput   => true,
     refreshonly => true,
   }


### PR DESCRIPTION
When upgrading from Harbor 1.10.0 to 1.10.4 we noticed some issues which this pull request resolves.
Details:
Fix typo in parameter "backup_directory". Fix typo in meta parameter "require". Add parameter "image_tag" with new Harbor version to "docker::image" resource in order to become the resource aware of the right image. Otherwise it would simply detect the image of the old Harbor version and not load new images from tar file. Disabled timeout for "exec" resource "prepare_harbor" because it can take longer (depends on registry content's size) than the default timeout which is 300 sec to finalize the new Harbor version.