### PR TITLE
Check for existence of the "harbor_systeminfo" fact before accessing it

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -257,16 +257,18 @@ class harbor (
   }
 
   if $backup_enabled {
-    if !empty($facts['harbor_systeminfo']['harbor_version']) {
-      $_running_version = $facts['harbor_systeminfo']['harbor_version'].match(/^v(\d+\.\d+\.\d+)/)[1]
-      if versioncmp($version, $_running_version) > 0 {
-        class { 'harbor::backup':
-          version        => $_running_version,
-          data_volume    => $data_volume,
-          back_directory => $backup_directory,
-          before         => Class['harbor::install'],
+    if $facts['harbor_systeminfo'] {
+      if !empty($facts['harbor_systeminfo']['harbor_version']) {
+        $_running_version = $facts['harbor_systeminfo']['harbor_version'].match(/^v(\d+\.\d+\.\d+)/)[1]
+        if versioncmp($version, $_running_version) > 0 {
+          class { 'harbor::backup':
+            version        => $_running_version,
+            data_volume    => $data_volume,
+            back_directory => $backup_directory,
+            before         => Class['harbor::install'],
+          }
+          contain 'harbor::backup'
         }
-        contain 'harbor::backup'
       }
     }
   }


### PR DESCRIPTION
Avoid accessing the fact "harbor_systeminfo" in the "init.pp" manifest if it was not available.