### PR TITLE
Add resource "harbor_ldap_user_group"

### DIFF
--- a/lib/puppet/provider/harbor_ldap_user_group/swagger.rb
+++ b/lib/puppet/provider/harbor_ldap_user_group/swagger.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+Puppet::Type.type(:harbor_ldap_user_group).provide(:swagger) do
+  mk_resource_methods
+  desc 'Swagger API implementation for harbor LDAP user group'
+
+  def self.instances
+    api_instance = do_login
+    groups = api_instance.usergroups_get
+    if groups.nil?
+      []
+    else
+      groups.map do |group|
+        new(
+          ensure:        :present,
+          group_name:    group.group_name,
+          ldap_group_dn: group.ldap_group_dn,
+          provider:      :swagger,
+        )
+      end
+    end
+  end
+
+  def self.do_login
+    require 'yaml'
+    require 'harbor_swagger_client'
+    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
+
+    SwaggerClient.configure do |config|
+      config.username = my_config['username']
+      config.password = my_config['password']
+      config.scheme = my_config['scheme']
+      config.verify_ssl = my_config['verify_ssl']
+      config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
+    end
+
+    api_instance = SwaggerClient::ProductsApi.new
+    api_instance
+  end
+
+  def self.prefetch(resources)
+    instances.each do |int|
+      if (resource = resources[int.ldap_group_dn])
+        resource.provider = int
+      end
+    end
+  end
+
+  def exists?
+    group = get_group_with_ldap_dn(resource[:ldap_group_dn])
+    !group.nil?
+  end
+
+  def get_group_with_ldap_dn(dn)
+    groups = get_groups_containing_ldap_dn(dn)
+    filtered = filter_group_matching_ldap_dn(groups, dn)
+    filtered
+  end
+
+  def get_groups_containing_ldap_dn(dn)
+    opts = { ldap_group_dn: dn }
+    get_groups_with_opts(opts)
+  end
+
+  def get_groups_with_opts(opts)
+    api_instance = self.class.do_login
+    begin
+      groups = api_instance.usergroups_get(opts)
+      groups.nil? ? [] : groups
+    rescue SwaggerClient::ApiError => e
+      puts "Exception when calling ProductsApi->usergroups_get: #{e}"
+    end
+  end
+
+  def filter_group_matching_ldap_dn(all_groups, dn)
+    filtered = all_groups.select { |p| p.ldap_group_dn == dn }
+    filtered.empty? ? nil : filtered[0]
+  end
+
+  def create
+    group = SwaggerClient::UserGroup.new(
+      group_name: resource[:group_name],
+      group_type: 1,
+      ldap_group_dn: resource[:ldap_group_dn],
+    )
+    api_instance = self.class.do_login
+    begin
+      api_instance.usergroups_post(opts = {usergroup: group})
+    rescue SwaggerClient::ApiError => e
+      puts "Exception when calling ProductsApi->usergroups_post: #{e}"
+    end
+  end
+
+  def group_name=(_value)
+    group = SwaggerClient::UserGroup.new(
+      group_name: _value,
+      group_type: 1,
+      ldap_group_dn: resource[:ldap_group_dn],
+    )
+    id = get_id_of_group_with_ldap_dn(resource[:ldap_group_dn])
+    update_group_with_id(id, group)
+  end
+
+  def get_id_of_group_with_ldap_dn(dn)
+    group = get_group_with_ldap_dn(dn)
+    group.id
+  end
+
+  def update_group_with_id(id, group)
+    api_instance = self.class.do_login
+    begin
+      api_instance.usergroups_group_id_put(id, opts = {usergroup: group})
+    rescue SwaggerClient::ApiError => e
+      puts "Exception when calling ProductsApi->usergroups_group_id_put: #{e}"
+    end
+  end
+
+  def destroy
+    group = get_group_with_ldap_dn(resource[:ldap_group_dn])
+    delete_group_with_id(group.id)
+  end
+
+  def delete_group_with_id(id)
+    api_instance = self.class.do_login
+    begin
+      api_instance.usergroups_group_id_delete(id)
+    rescue SwaggerClient::ApiError => e
+      puts "Exception when calling ProductsApi->usergroups_group_id_delete: #{e}"
+    end
+  end
+end

--- a/lib/puppet/provider/harbor_project/swagger.rb
+++ b/lib/puppet/provider/harbor_project/swagger.rb
@@ -162,7 +162,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
     members_to_add = members - current_members
 
     remove_members_from_project(id, members_to_delete) unless members_to_delete.empty?
-    add_members_to_project(id, members) unless members_to_add.empty?
+    add_members_to_project(id, members_to_add) unless members_to_add.empty?
   end
 
   def remove_members_from_project(project_id, member_names)
@@ -214,7 +214,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
     member_groups_to_add = member_groups - current_member_groups
 
     remove_member_groups_from_project(project_id, member_groups_to_delete) unless member_groups_to_delete.empty?
-    add_member_groups_to_project(project_id, member_groups) unless member_groups_to_add.empty?
+    add_member_groups_to_project(project_id, member_groups_to_add) unless member_groups_to_add.empty?
   end
 
   def remove_member_groups_from_project(project_id, group_names)

--- a/lib/puppet/type/harbor_ldap_user_group.rb
+++ b/lib/puppet/type/harbor_ldap_user_group.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+Puppet::Type.newtype(:harbor_ldap_user_group) do
+  @doc = %q{Manages an LDAP user groups within Harbor.
+
+    Example creating an LDAP user group giving the LDAP group DN as title of the resource:
+
+        harbor_ldap_user_group {'cn=ProjectA,ou=Users,dc=example,dc=local':
+          ensure     => present,
+          group_name => 'project_a',
+        }
+
+    Example creating an LDAP user group with separate title:
+
+        harbor_ldap_user_group {'Members of project A':
+          ensure        => present,
+          ldap_group_dn => 'cn=ProjectA,ou=Users,dc=example,dc=local',
+          group_name    => 'project_a',
+        }
+
+    Example remove an LDAP user group:
+
+        harbor_ldap_user_group {'cn=ProjectA,ou=Users,dc=example,dc=local':
+          ensure => absent,
+        }
+  }
+
+  ensurable
+
+  newparam(:ldap_group_dn, namevar: true) do
+    desc 'The DN of the LDAP group. This is taken from resource\'s name if not
+     explicitly set. It cannot be changed once the resource was created.'
+  end
+
+  newproperty(:group_name) do
+    desc 'The name of the user group. This has to be unique within the Harbor
+      installation. It can be changed for an existing group.'
+  end
+
+end

--- a/spec/unit/puppet/provider/harbor_ldap_user_group/swagger_spec.rb
+++ b/spec/unit/puppet/provider/harbor_ldap_user_group/swagger_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:harbor_ldap_user_group).provider(:swagger) do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      describe 'when validating class interface' do
+        [ :instances, :prefetch ].each do |method|
+          it "should have a method \"#{method}\"" do
+            expect(described_class).to respond_to :method
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/harbor_ldap_user_group.rb
+++ b/spec/unit/puppet/type/harbor_ldap_user_group.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'rspec-puppet'
+
+describe Puppet::Type.type(:harbor_ldap_user_group) do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      describe 'when validating attributes' do
+        [ :ldap_group_dn ].each do |param|
+          it "should have a parameter '#{param}'" do
+            expect(described_class.attrtype(param)).to eq(:param)
+          end
+        end
+        [ :ensure, :group_name ].each do |prop|
+          it "should have a property '#{prop}'" do
+            expect(described_class.attrtype(prop)).to eq(:property)
+          end
+        end
+      end
+
+      describe "namevar validation" do
+        it "should have :ldap_group_dn as its namevar" do
+          expect(described_class.key_attributes).to eq([:ldap_group_dn])
+        end
+      end
+
+      describe 'when validating attribute values' do
+        describe 'ensure' do
+          [ :present, :absent ].each do |value|
+            it "should support value '#{value}'" do
+              expect { described_class.new({
+                :ensure        => value,
+                :ldap_group_dn => 'cn=ProjectA,ou=Users,dc=example,dc=local',
+                :group_name    => 'the_name',
+              })}.to_not raise_error
+            end
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :ldap_group_dn => 'dn',
+              :group_name    => 'the_name',
+              :ensure        => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+
+          it "should default to :present" do
+            expect(described_class.new({
+              :ldap_group_dn => 'dn',
+              :group_name    => 'the_name',
+            })[:ensure]).to eq :present
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This can be used to add, remove or rename an LDAP group to/from/in Harbor. We added that resource because we noticed that Harbor does not automatically add all or even none groups of a configured LDAP server.
The name of the resource can be changed but not the LDAP group dn because this is the unique property that Harbor uses to identify an exiting group. That's why the LDAP group dn is set as "namevar" of the type.

Note that the upper lower writing of the name's characters matters because Harbor distinguishes between upper and lower characters in group names.

