### PR TITLE
Support Harbor v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 .project
 .envrc
 /inventory.yaml
+Vagrantfile
+/vagrant/

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Include usage examples for common use cases in the **Usage** section. Show your 
 
 This module comes with types and providers to manage harbor user setttings (https://github.com/goharbor/harbor/blob/master/docs/configure_user_settings.md#harbor-user-settings) and harbor projects via Harbor's swagger API.
 
-To use these features you must install the harbor-swagger-client gem (https://github.com/bt-lemery/harbor-swagger-client) and create the file '/etc/puppetlabs/swagger.yaml' on your Harbor server with the following (minimum) content:
+To use these features with Harbor v1.x, you must install the [harbor1_client gem](https://rubygems.org/gems/harbor1_client). To use these features with Harbor v2.x, you must install the [harbor2_client gem](https://rubygems.org/gems/harbor2_client) and the [harbor2_legacy_client_gem](https://rubygems.org/gems/harbor2_legacy_client).
+
+You must also create the file '/etc/puppetlabs/swagger.yaml' on your Harbor server with the following (minimum) content:
 
 ```
 ---
@@ -56,6 +58,11 @@ If using Harbor with a self-signed SSL certificate you should also include:
 ```
 verify_ssl: false
 verify_ssl_host: false
+```
+
+If using Harbor v2.x, you should also include:
+```
+api_version: 2
 ```
 
 ### User settings

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,7 +1,7 @@
 ---
-harbor::version: '1.9.2'
-harbor::release: '1.9.0'
-harbor::checksum: '6da2f6ff3be598b5c657a9b204bda8af'
+harbor::version: '2.1.2'
+harbor::release: '2.1.0'
+harbor::checksum: '37a84e078504546c24e6fb99f80f6d05'
 harbor::installer: 'offline'
 harbor::with_notary: false
 harbor::with_clair: false

--- a/lib/puppet/provider/harbor_system_label/swagger.rb
+++ b/lib/puppet/provider/harbor_system_label/swagger.rb
@@ -6,9 +6,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
 
   def self.instances
     api_instance = do_login
-
-    labels = api_instance.labels_get('g')
-
+    labels = api_instance[:legacy_client].labels_get('g')
     labels.map do |label|
       new(
         ensure: :present,
@@ -30,108 +28,138 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
 
   def self.do_login
     require 'yaml'
-    require 'harbor_swagger_client'
     my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-
-    SwaggerClient.configure do |config|
-      config.username = my_config['username']
-      config.password = my_config['password']
-      config.scheme = my_config['scheme']
-      config.verify_ssl = my_config['verify_ssl']
-      config.verify_ssl_host = my_config['verify_ssl_host']
-      config.ssl_ca_cert = my_config['ssl_ca_cert']
-      if my_config['host']
-        config.host = my_config['host']
+    require 'harbor2_client'
+    require 'harbor2_legacy_client'
+    require 'harbor1_client'
+    if my_config.fetch('api_version', 1) == 2
+      Harbor2Client.configure do |config|
+        config.username = my_config['username']
+        config.password = my_config['password']
+        config.scheme = my_config['scheme']
+        config.verify_ssl = my_config['verify_ssl']
+        config.verify_ssl_host = my_config['verify_ssl_host']
+        config.ssl_ca_cert = my_config['ssl_ca_cert']
+        if my_config['host']
+          config.host = my_config['host']
+        end
       end
+      Harbor2LegacyClient.configure do |config|
+        config.username = my_config['username']
+        config.password = my_config['password']
+        config.scheme = my_config['scheme']
+        config.verify_ssl = my_config['verify_ssl']
+        config.verify_ssl_host = my_config['verify_ssl_host']
+        config.ssl_ca_cert = my_config['ssl_ca_cert']
+        if my_config['host']
+          config.host = my_config['host']
+        end
+      end
+      api_instance = {
+        :api_version => 2,
+        :client => Harbor2Client::ProjectApi.new,
+        :legacy_client => Harbor2LegacyClient::ProductsApi.new
+      }
+    else
+      Harbor1Client.configure do |config|
+        config.username = my_config['username']
+        config.password = my_config['password']
+        config.scheme = my_config['scheme']
+        config.verify_ssl = my_config['verify_ssl']
+        config.verify_ssl_host = my_config['verify_ssl_host']
+        config.ssl_ca_cert = my_config['ssl_ca_cert']
+        if my_config['host']
+          config.host = my_config['host']
+        end
+      end
+      client = Harbor1Client::ProductsApi.new
+      api_instance = {
+        :api_version => 1,
+        :client => client,
+        :legacy_client => client
+      }
     end
-
-    api_instance = SwaggerClient::ProductsApi.new
     api_instance
   end
 
   def get_label_id_by_name(label_name)
     api_instance = self.class.do_login
-
     opts = {
       name: label_name,
     }
-
     begin
-      label = api_instance.labels_get('g', opts)
-    rescue SwaggerClient::ApiError => e
+      label = api_instance[:legacy_client].labels_get('g', opts)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->labels_get: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->labels_get: #{e}"
     end
-
     label[0].id
   end
 
   def name=(_value)
     api_instance = self.class.do_login
-
     id = get_label_id_by_name(resource[:name])
-
     label = {
       "name": resource[:name],
       "description": resource[:description],
       "color": resource[:color],
     }
-
     begin
-      api_instance.labels_id_put(id, label)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].labels_id_put(id, label)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->labels_id_put for color: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->labels_id_put for color: #{e}"
     end
   end
 
   def description=(_value)
     api_instance = self.class.do_login
-
     id = get_label_id_by_name(resource[:name])
-
     label = {
       "name": resource[:name],
       "description": resource[:description],
       "color": resource[:color],
     }
-
     begin
-      api_instance.labels_id_put(id, label)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].labels_id_put(id, label)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->labels_id_put for color: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->labels_id_put for color: #{e}"
     end
   end
 
   def color=(_value)
     api_instance = self.class.do_login
-
     id = get_label_id_by_name(resource[:name])
-
     label = {
       "name": resource[:name],
       "description": resource[:description],
       "color": resource[:color],
     }
-
     begin
-      api_instance.labels_id_put(id, label)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].labels_id_put(id, label)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->labels_id_put for color: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->labels_id_put for color: #{e}"
     end
   end
 
   def exists?
     api_instance = self.class.do_login
-
     opts = {
       name: resource[:name],
     }
-
     begin
-      result = api_instance.labels_get('g', opts)
-    rescue SwaggerClient::ApiError => e
+      result = api_instance[:legacy_client].labels_get('g', opts)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->labels_get: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->labels_get: #{e}"
     end
-
     if result.empty?
       false
     else
@@ -141,25 +169,30 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
 
   def create
     api_instance = self.class.do_login
-
-    nl = SwaggerClient::Label.new(name: resource[:name], description: resource[:description], color: resource[:color], scope: 'g')
-
+    if api_instance[:api_version] == 2
+      nl = Harbor2LegacyClient::Label.new(name: resource[:name], description: resource[:description], color: resource[:color], scope: 'g')
+    else
+      nl = Harbor1Client::Label.new(name: resource[:name], description: resource[:description], color: resource[:color], scope: 'g')
+    end
     begin
-      api_instance.labels_post(nl)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].labels_post(nl)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->labels_post: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->labels_post: #{e}"
     end
   end
 
   def destroy
     api_instance = self.class.do_login
-
     label_id = get_label_id_by_name(resource[:name])
-
     begin
-      api_instance.labels_id_delete(label_id)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].labels_id_delete(label_id)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->labels_id_delete: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->labels_id_delete: #{e}"
     end
   end
+
 end

--- a/lib/puppet/provider/harbor_user_settings/swagger.rb
+++ b/lib/puppet/provider/harbor_user_settings/swagger.rb
@@ -6,29 +6,66 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def do_login
     require 'yaml'
-    require 'harbor_swagger_client'
     my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-
-    SwaggerClient.configure do |config|
-      config.username = my_config['username']
-      config.password = my_config['password']
-      config.scheme = my_config['scheme']
-      config.verify_ssl = my_config['verify_ssl']
-      config.verify_ssl_host = my_config['verify_ssl_host']
-      config.ssl_ca_cert = my_config['ssl_ca_cert']
-      if my_config['host']
-        config.host = my_config['host']
+    require 'harbor2_client'
+    require 'harbor2_legacy_client'
+    require 'harbor1_client'
+    if my_config.fetch('api_version', 1) == 2
+      Harbor2Client.configure do |config|
+        config.username = my_config['username']
+        config.password = my_config['password']
+        config.scheme = my_config['scheme']
+        config.verify_ssl = my_config['verify_ssl']
+        config.verify_ssl_host = my_config['verify_ssl_host']
+        config.ssl_ca_cert = my_config['ssl_ca_cert']
+        if my_config['host']
+          config.host = my_config['host']
+        end
       end
+      Harbor2LegacyClient.configure do |config|
+        config.username = my_config['username']
+        config.password = my_config['password']
+        config.scheme = my_config['scheme']
+        config.verify_ssl = my_config['verify_ssl']
+        config.verify_ssl_host = my_config['verify_ssl_host']
+        config.ssl_ca_cert = my_config['ssl_ca_cert']
+        if my_config['host']
+          config.host = my_config['host']
+        end
+      end
+      api_instance = {
+        :api_version => 2,
+        :client => Harbor2Client::ProjectApi.new,
+        :legacy_client => Harbor2LegacyClient::ProductsApi.new
+      }
+    else
+      Harbor1Client.configure do |config|
+        config.username = my_config['username']
+        config.password = my_config['password']
+        config.scheme = my_config['scheme']
+        config.verify_ssl = my_config['verify_ssl']
+        config.verify_ssl_host = my_config['verify_ssl_host']
+        config.ssl_ca_cert = my_config['ssl_ca_cert']
+        if my_config['host']
+          config.host = my_config['host']
+        end
+      end
+      client = Harbor1Client::ProductsApi.new
+      api_instance = {
+        :api_version => 1,
+        :client => client,
+        :legacy_client => client
+      }
     end
-
-    api_instance = SwaggerClient::ProductsApi.new
     api_instance
   end
 
   def get_config(api_instance)
     begin
-      config = api_instance.configurations_get
-    rescue SwaggerClient::ApiError => e
+      config = api_instance[:legacy_client].configurations_get
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_get: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_get: #{e}"
     end
     config
@@ -48,8 +85,10 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
     }
 
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for auth_mode: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for auth_mode: #{e}"
     end
   end
@@ -62,14 +101,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def email_from=(_value)
     api_instance = do_login
-
     configurations = {
       "email_from": resource[:email_from],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for email_from: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for email_from: #{e}"
     end
   end
@@ -82,14 +121,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def email_host=(_value)
     api_instance = do_login
-
     configurations = {
       "email_host": resource[:email_host],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for email_host: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for email_host: #{e}"
     end
   end
@@ -102,14 +141,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def email_port=(_value)
     api_instance = do_login
-
     configurations = {
       "email_port": resource[:email_port],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for email_port: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for email_port: #{e}"
     end
   end
@@ -122,14 +161,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def email_identity=(_value)
     api_instance = do_login
-
     configurations = {
       "email_identity": resource[:email_identity],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for email_identity: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for email_identity: #{e}"
     end
   end
@@ -142,14 +181,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def email_username=(_value)
     api_instance = do_login
-
     configurations = {
       "email_username": resource[:email_username],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for email_username: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for email_username: #{e}"
     end
   end
@@ -162,14 +201,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def email_ssl=(_value)
     api_instance = do_login
-
     configurations = {
       "email_ssl": resource[:email_ssl],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for email_ssl: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for email_ssl: #{e}"
     end
   end
@@ -182,14 +221,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def email_insecure=(_value)
     api_instance = do_login
-
     configurations = {
       "email_insecure": resource[:email_insecure],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for email_insecure: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for email_insecure: #{e}"
     end
   end
@@ -202,14 +241,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def ldap_url=(_value)
     api_instance = do_login
-
     configurations = {
       "ldap_url": resource[:ldap_url],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for ldap_url: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for ldap_url: #{e}"
     end
   end
@@ -222,14 +261,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def ldap_base_dn=(_value)
     api_instance = do_login
-
     configurations = {
       "ldap_base_dn": resource[:ldap_base_dn],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for ldap_base_dn: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for ldap_base_dn: #{e}"
     end
   end
@@ -242,14 +281,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def ldap_filter=(_value)
     api_instance = do_login
-
     configurations = {
       "ldap_filter": resource[:ldap_filter],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for ldap_filter: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for ldap_filter: #{e}"
     end
   end
@@ -262,14 +301,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def ldap_scope=(_value)
     api_instance = do_login
-
     configurations = {
       "ldap_scope": resource[:ldap_scope],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for ldap_scope: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for ldap_scope: #{e}"
     end
   end
@@ -282,14 +321,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def ldap_uid=(_value)
     api_instance = do_login
-
     configurations = {
       "ldap_uid": resource[:ldap_uid],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for ldap_uid: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for ldap_uid: #{e}"
     end
   end
@@ -302,14 +341,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def ldap_search_dn=(_value)
     api_instance = do_login
-
     configurations = {
       "ldap_search_dn": resource[:ldap_search_dn],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for ldap_search_dn: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for ldap_search_dn: #{e}"
     end
   end
@@ -322,14 +361,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def ldap_timeout=(_value)
     api_instance = do_login
-
     configurations = {
       "ldap_timeout": resource[:ldap_timeout],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for ldap_timeout: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for ldap_timeout: #{e}"
     end
   end
@@ -342,14 +381,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def ldap_group_attribute_name=(_value)
     api_instance = do_login
-
     configurations = {
       "ldap_group_attribute_name": resource[:ldap_group_attribute_name],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for ldap_group_attribute_name: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for ldap_group_attribute_name: #{e}"
     end
   end
@@ -362,14 +401,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def ldap_group_base_dn=(_value)
     api_instance = do_login
-
     configurations = {
       "ldap_group_base_dn": resource[:ldap_group_base_dn],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for ldap_group_base_dn: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for ldap_group_base_dn: #{e}"
     end
   end
@@ -382,14 +421,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def ldap_group_search_filter=(_value)
     api_instance = do_login
-
     configurations = {
       "ldap_group_search_filter": resource[:ldap_group_search_filter],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for ldap_group_search_filter: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for ldap_group_search_filter: #{e}"
     end
   end
@@ -402,14 +441,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def ldap_group_search_scope=(_value)
     api_instance = do_login
-
     configurations = {
       "ldap_group_search_scope": resource[:ldap_group_search_scope],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for ldap_group_search_scope: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for ldap_group_search_scope: #{e}"
     end
   end
@@ -422,14 +461,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def ldap_group_admin_dn=(_value)
     api_instance = do_login
-
     configurations = {
       "ldap_group_admin_dn": resource[:ldap_group_admin_dn],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for ldap_group_admin_dn: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for ldap_group_admin_dn: #{e}"
     end
   end
@@ -442,15 +481,15 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def project_creation_restriction=(_value)
     api_instance = do_login
-
     configurations = {
       "project_creation_restriction": resource[:project_creation_restriction],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
-      puts "Exception when calling ProductsApi->configurations_put for projection_creation_restriction: #{e}"
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for project_creation_restriction: #{e}"
+    rescue Harbor1Client::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for project_creation_restriction: #{e}"
     end
   end
 
@@ -462,14 +501,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def read_only=(_value)
     api_instance = do_login
-
     configurations = {
       "read_only": resource[:read_only],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for read_only: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for read_only: #{e}"
     end
   end
@@ -482,14 +521,14 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def self_registration=(_value)
     api_instance = do_login
-
     configurations = {
       "self_registration": resource[:self_registration],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for self_registration: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for self_registration: #{e}"
     end
   end
@@ -502,15 +541,16 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
 
   def token_expiration=(_value)
     api_instance = do_login
-
     configurations = {
       "token_expiration": resource[:token_expiration],
     }
-
     begin
-      api_instance.configurations_put(configurations)
-    rescue SwaggerClient::ApiError => e
+      api_instance[:legacy_client].configurations_put(configurations)
+    rescue Harbor2LegacyClient::ApiError => e
+      puts "Exception when calling ProductsApi->configurations_put for token_expiration: #{e}"
+    rescue Harbor1Client::ApiError => e
       puts "Exception when calling ProductsApi->configurations_put for token_expiration: #{e}"
     end
   end
+
 end

--- a/spec/classes/harbor_spec.rb
+++ b/spec/classes/harbor_spec.rb
@@ -17,11 +17,11 @@ describe 'harbor' do
       describe 'harbor::install' do
         context 'with init default params' do
           it do
-            is_expected.to contain_archive('/tmp/harbor-offline-installer-v1.9.2.tgz').with(
-              'source' => 'https://storage.googleapis.com/harbor-releases/release-1.9.0/harbor-offline-installer-v1.9.2.tgz',
+            is_expected.to contain_archive('/tmp/harbor-offline-installer-v2.1.1.tgz').with(
+              'source' => 'https://storage.googleapis.com/harbor-releases/release-2.1.0/harbor-offline-installer-v2.1.1.tgz',
             )
           end
-          it { is_expected.to contain_file('/opt/harbor-v1.9.2') }
+          it { is_expected.to contain_file('/opt/harbor-v2.1.1') }
           it { is_expected.to contain_file('/opt/harbor') }
           it { is_expected.to contain_docker__image('goharbor/harbor-log') }
         end


### PR DESCRIPTION
- Support Harbor v2
- Continued support for Harbor v1
- Support v1, v2 and v2_legacy APIs (simultaneously)
- Use new client gems:
  - [harbor2_client](https://github.com/liger1978/ruby-harbor2_client/)
  - [harbor2_legacy_client](https://github.com/liger1978/ruby-harbor2_legacy_client/)
  - [harbor1_client](https://github.com/liger1978/ruby-harbor1_client)
  
**The requirement for the new gems counts as a breaking change, so this should result in a new major release**.