### PR TITLE
Implement settings migration for Harbor v2

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -108,7 +108,7 @@ class harbor::config (
   }
 
   $migrate_command = versioncmp($harbor::version, '2.0.0') < 0 ? {
-    true    => "/usr/bin/docker run --rm -v harbor.yml:/harbor-migration/harbor-cfg/harbor.yml -v harbor.yml:/harbor-migration/harbor-cfg-out/harbor.yml goharbor/harbor-migrator:${cfg_version} --cfg up",
+    true    => "/usr/bin/docker run --rm -v harbor.yml:/harbor-migration/harbor-cfg/harbor.yml -v harbor.yml:/harbor-migration/harbor-cfg-out/harbor.yml goharbor/harbor-migrator:v${cfg_version} --cfg up",
     default => "/usr/bin/docker run --rm -v /:/hostfs goharbor/prepare:v${harbor::version} migrate -i /opt/harbor-v${harbor::version}/harbor/harbor.yml",
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -350,7 +350,7 @@ class harbor (
   contain 'harbor::service'
 
   Class['harbor::install']
-  -> Class['harbor::config']
+  ~> Class['harbor::config']
   ~> Class['harbor::prepare']
   ~> Class['harbor::service']
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'harbor' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      describe 'harbor::config' do
+        context 'with init default params' do
+          it do
+            is_expected.to contain_file('/opt/harbor/harbor.yml').with_content(/^_version: 2.1.0$/)
+            is_expected.to contain_exec('migrate_cfg').with(
+              'cwd' => '/opt/harbor',
+              'command' => "/usr/bin/docker run --rm -v /:/hostfs goharbor/prepare:v2.1.2 migrate -i /opt/harbor-v2.1.2/harbor/harbor.yml"
+            )
+          end
+        end
+        context 'with harbor version < 2.0.0' do
+          let(:params) { {'version' => '1.10.6'} }
+          it do
+            is_expected.to contain_file('/opt/harbor/harbor.yml').with_content(/^_version: 1.10.0$/)
+            is_expected.to contain_exec('migrate_cfg').with(
+              'cwd' => '/opt/harbor',
+              'command' => "/usr/bin/docker run --rm -v harbor.yml:/harbor-migration/harbor-cfg/harbor.yml -v harbor.yml:/harbor-migration/harbor-cfg-out/harbor.yml goharbor/harbor-migrator:1.10.0 --cfg up"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -23,7 +23,7 @@ describe 'harbor' do
             is_expected.to contain_file('/opt/harbor/harbor.yml').with_content(/^_version: 1.10.0$/)
             is_expected.to contain_exec('migrate_cfg').with(
               'cwd' => '/opt/harbor',
-              'command' => "/usr/bin/docker run --rm -v harbor.yml:/harbor-migration/harbor-cfg/harbor.yml -v harbor.yml:/harbor-migration/harbor-cfg-out/harbor.yml goharbor/harbor-migrator:1.10.0 --cfg up"
+              'command' => "/usr/bin/docker run --rm -v harbor.yml:/harbor-migration/harbor-cfg/harbor.yml -v harbor.yml:/harbor-migration/harbor-cfg-out/harbor.yml goharbor/harbor-migrator:v1.10.0 --cfg up"
             )
           end
         end

--- a/spec/classes/harbor_spec.rb
+++ b/spec/classes/harbor_spec.rb
@@ -31,6 +31,7 @@ describe 'harbor' do
         context 'with init default params' do
           it do
             is_expected.to contain_file('/opt/harbor/harbor.yml')
+            is_expected.to contain_exec('migrate_cfg')
           end
         end
       end


### PR DESCRIPTION
I noticed that the Harbor v2 [upgrade guide](https://goharbor.io/docs/2.0.0/administration/upgrade) mentions changes for the settings migration. Note that the Docker image `goharbor/harbor-migrator:VERSION` is not available anymore with Harbor v2.
I further noticed that the `refreshonly` configured `exec` resource in `harbor::config` was never executed because the class `harbor::config` is never notified.
Additionally I noticed that there was the erroneous option '-it' in the migration 'docker run' command which makes the `exec` resource fail with error "the input device is not a TTY" and the tag of the Docker image missed the leading `v` character.
