### PR TITLE
Separate and share duplicated code in providers

### DIFF
--- a/lib/puppet/provider/harbor_ldap_user_group/swagger.rb
+++ b/lib/puppet/provider/harbor_ldap_user_group/swagger.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
+require 'puppet_x/walkamongus/harbor/client'
 
 Puppet::Type.type(:harbor_ldap_user_group).provide(:swagger) do
   mk_resource_methods
   desc 'Swagger API implementation for harbor LDAP user group'
 
   def self.instances
-    api_instance = do_login
+    api_instance = self.do_login
     groups = api_instance[:legacy_client].usergroups_get
     if groups.nil?
       []
@@ -22,59 +23,7 @@ Puppet::Type.type(:harbor_ldap_user_group).provide(:swagger) do
   end
 
   def self.do_login
-    require 'yaml'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-    require 'harbor2_client'
-    require 'harbor2_legacy_client'
-    require 'harbor1_client'
-    if my_config.fetch('api_version', 1) == 2
-      Harbor2Client.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      Harbor2LegacyClient.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      api_instance = {
-        :api_version => 2,
-        :client => Harbor2Client::ProjectApi.new,
-        :legacy_client => Harbor2LegacyClient::ProductsApi.new
-      }
-    else
-      Harbor1Client.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      client = Harbor1Client::ProductsApi.new
-      api_instance = {
-        :api_version => 1,
-        :client => client,
-        :legacy_client => client
-      }
-    end
-    api_instance
+     PuppetX::Walkamongus::Harbor::Client.do_login
   end
 
   def self.prefetch(resources)

--- a/lib/puppet/provider/harbor_project/swagger.rb
+++ b/lib/puppet/provider/harbor_project/swagger.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'puppet_x/walkamongus/harbor/client'
 
 Puppet::Type.type(:harbor_project).provide(:swagger) do
   mk_resource_methods
@@ -29,59 +30,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def self.do_login
-    require 'yaml'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-    require 'harbor2_client'
-    require 'harbor2_legacy_client'
-    require 'harbor1_client'
-    if my_config.fetch('api_version', 1) == 2
-      Harbor2Client.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      Harbor2LegacyClient.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      api_instance = {
-        :api_version => 2,
-        :client => Harbor2Client::ProjectApi.new,
-        :legacy_client => Harbor2LegacyClient::ProductsApi.new
-      }
-    else
-      Harbor1Client.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      client = Harbor1Client::ProductsApi.new
-      api_instance = {
-        :api_version => 1,
-        :client => client,
-        :legacy_client => client
-      }
-    end
-    api_instance
+     PuppetX::Walkamongus::Harbor::Client.do_login
   end
 
   def self.get_project_member_names(project_id)

--- a/lib/puppet/provider/harbor_registry/swagger.rb
+++ b/lib/puppet/provider/harbor_registry/swagger.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'puppet_x/walkamongus/harbor/client'
 
 Puppet::Type.type(:harbor_registry).provide(:swagger) do
   mk_resource_methods
@@ -36,59 +37,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def self.do_login
-    require 'yaml'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-    require 'harbor2_client'
-    require 'harbor2_legacy_client'
-    require 'harbor1_client'
-    if my_config.fetch('api_version', 1) == 2
-      Harbor2Client.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      Harbor2LegacyClient.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      api_instance = {
-        :api_version => 2,
-        :client => Harbor2Client::ProjectApi.new,
-        :legacy_client => Harbor2LegacyClient::ProductsApi.new
-      }
-    else
-      Harbor1Client.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      client = Harbor1Client::ProductsApi.new
-      api_instance = {
-        :api_version => 1,
-        :client => client,
-        :legacy_client => client
-      }
-    end
-    api_instance
+     PuppetX::Walkamongus::Harbor::Client.do_login
   end
 
   def exists?

--- a/lib/puppet/provider/harbor_replication_policy/swagger.rb
+++ b/lib/puppet/provider/harbor_replication_policy/swagger.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'puppet_x/walkamongus/harbor/client'
 
 Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   mk_resource_methods
@@ -58,59 +59,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def self.do_login
-    require 'yaml'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-    require 'harbor2_client'
-    require 'harbor2_legacy_client'
-    require 'harbor1_client'
-    if my_config.fetch('api_version', 1) == 2
-      Harbor2Client.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      Harbor2LegacyClient.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      api_instance = {
-        :api_version => 2,
-        :client => Harbor2Client::ProjectApi.new,
-        :legacy_client => Harbor2LegacyClient::ProductsApi.new
-      }
-    else
-      Harbor1Client.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      client = Harbor1Client::ProductsApi.new
-      api_instance = {
-        :api_version => 1,
-        :client => client,
-        :legacy_client => client
-      }
-    end
-    api_instance
+     PuppetX::Walkamongus::Harbor::Client.do_login
   end
 
   def exists?

--- a/lib/puppet/provider/harbor_system_label/swagger.rb
+++ b/lib/puppet/provider/harbor_system_label/swagger.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'puppet_x/walkamongus/harbor/client'
 
 Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   mk_resource_methods
@@ -27,59 +28,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def self.do_login
-    require 'yaml'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-    require 'harbor2_client'
-    require 'harbor2_legacy_client'
-    require 'harbor1_client'
-    if my_config.fetch('api_version', 1) == 2
-      Harbor2Client.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      Harbor2LegacyClient.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      api_instance = {
-        :api_version => 2,
-        :client => Harbor2Client::ProjectApi.new,
-        :legacy_client => Harbor2LegacyClient::ProductsApi.new
-      }
-    else
-      Harbor1Client.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      client = Harbor1Client::ProductsApi.new
-      api_instance = {
-        :api_version => 1,
-        :client => client,
-        :legacy_client => client
-      }
-    end
-    api_instance
+     PuppetX::Walkamongus::Harbor::Client.do_login
   end
 
   def get_label_id_by_name(label_name)

--- a/lib/puppet/provider/harbor_user_settings/swagger.rb
+++ b/lib/puppet/provider/harbor_user_settings/swagger.rb
@@ -1,63 +1,12 @@
 # frozen_string_literal: true
+require 'puppet_x/walkamongus/harbor/client'
 
 Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
   mk_resource_methods
   desc 'Swagger API implementation for harbor system configurations'
 
   def do_login
-    require 'yaml'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-    require 'harbor2_client'
-    require 'harbor2_legacy_client'
-    require 'harbor1_client'
-    if my_config.fetch('api_version', 1) == 2
-      Harbor2Client.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      Harbor2LegacyClient.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      api_instance = {
-        :api_version => 2,
-        :client => Harbor2Client::ProjectApi.new,
-        :legacy_client => Harbor2LegacyClient::ProductsApi.new
-      }
-    else
-      Harbor1Client.configure do |config|
-        config.username = my_config['username']
-        config.password = my_config['password']
-        config.scheme = my_config['scheme']
-        config.verify_ssl = my_config['verify_ssl']
-        config.verify_ssl_host = my_config['verify_ssl_host']
-        config.ssl_ca_cert = my_config['ssl_ca_cert']
-        if my_config['host']
-          config.host = my_config['host']
-        end
-      end
-      client = Harbor1Client::ProductsApi.new
-      api_instance = {
-        :api_version => 1,
-        :client => client,
-        :legacy_client => client
-      }
-    end
-    api_instance
+     PuppetX::Walkamongus::Harbor::Client.do_login
   end
 
   def get_config(api_instance)

--- a/lib/puppet_x/walkamongus/harbor/client.rb
+++ b/lib/puppet_x/walkamongus/harbor/client.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require 'puppet_x/walkamongus/harbor/harbor'
+
+class PuppetX::Walkamongus::Harbor::Client
+
+  def self.do_login
+    require 'yaml'
+    config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
+    if config.fetch('api_version', 1) == 2
+      api_instance = self.do_login_api_v2(config)
+    else
+      api_instance = self.do_login_api_v1(config)
+    end
+    api_instance
+  end
+
+  def self.do_login_api_v2(client_config)
+    require 'harbor2_client'
+    require 'harbor2_legacy_client'
+    Harbor2Client.configure do |config|
+      config.username = client_config['username']
+      config.password = client_config['password']
+      config.scheme = client_config['scheme']
+      config.verify_ssl = client_config['verify_ssl']
+      config.verify_ssl_host = client_config['verify_ssl_host']
+      config.ssl_ca_cert = client_config['ssl_ca_cert']
+      if client_config['host']
+        config.host = client_config['host']
+      end
+    end
+    Harbor2LegacyClient.configure do |config|
+      config.username = client_config['username']
+      config.password = client_config['password']
+      config.scheme = client_config['scheme']
+      config.verify_ssl = client_config['verify_ssl']
+      config.verify_ssl_host = client_config['verify_ssl_host']
+      config.ssl_ca_cert = client_config['ssl_ca_cert']
+      if client_config['host']
+        config.host = client_config['host']
+      end
+    end
+    api_instance = {
+      :api_version => 2,
+      :client => Harbor2Client::ProjectApi.new,
+      :legacy_client => Harbor2LegacyClient::ProductsApi.new
+    }
+  end
+
+  def self.do_login_api_v1(client_config)
+    require 'harbor1_client'
+    Harbor1Client.configure do |config|
+      config.username = client_config['username']
+      config.password = client_config['password']
+      config.scheme = client_config['scheme']
+      config.verify_ssl = client_config['verify_ssl']
+      config.verify_ssl_host = client_config['verify_ssl_host']
+      config.ssl_ca_cert = client_config['ssl_ca_cert']
+      if client_config['host']
+        config.host = client_config['host']
+      end
+    end
+    client = Harbor1Client::ProductsApi.new
+    api_instance = {
+      :api_version => 1,
+      :client => client,
+      :legacy_client => client
+    }
+  end
+
+end

--- a/lib/puppet_x/walkamongus/harbor/harbor.rb
+++ b/lib/puppet_x/walkamongus/harbor/harbor.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module PuppetX
+  module Walkamongus
+    module Harbor
+    end
+  end
+end


### PR DESCRIPTION
The providers duplicate code to login into Harbor registry using the swagger client. I added specific module and class in lib/puppet_x as recommended (as far as I was able to found examples) which the providers now call.