### PR TITLE
Fix provider of harbor_replication_policy

### DIFF
--- a/lib/puppet/provider/harbor_replication_policy/swagger.rb
+++ b/lib/puppet/provider/harbor_replication_policy/swagger.rb
@@ -131,7 +131,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def get_policies_with_opts(opts)
-    api_instance self.class.do_login
+    api_instance = self.class.do_login
     begin
       api_instance[:legacy_client].replication_policies_get(opts)
     rescue Harbor2LegacyClient::ApiError => e


### PR DESCRIPTION
I noticed a syntax error in provider of type harbor_replication_policy. A '=' got lost during implementation of Harbor v2 support.