### PR TITLE
Rework request to get all projects by iterating over pages

### DIFF
--- a/lib/puppet/provider/harbor_project/swagger.rb
+++ b/lib/puppet/provider/harbor_project/swagger.rb
@@ -5,25 +5,40 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   desc 'Swagger API implementation for harbor projects'
 
   def self.instances
-    api_instance = do_login
-    if api_instance[:api_version] == 2
-      projects = api_instance[:client].list_projects
-    else
-      projects = api_instance[:client].projects_get
+    projects = get_all_projects
+    projects.map do |project|
+      new(
+        ensure:        :present,
+        name:          project.name,
+        public:        project.metadata.public,
+        auto_scan:     project.metadata.auto_scan.nil? ? :false : project.metadata.auto_scan.to_sym,
+        members:       get_project_member_names(project.project_id),
+        member_groups: get_project_member_group_names(project.project_id),
+        provider:      :swagger,
+      )
     end
-    if projects.nil?
-      []
-    else
-      projects.map do |project|
-        new(
-          ensure:        :present,
-          name:          project.name,
-          public:        project.metadata.public,
-          auto_scan:     project.metadata.auto_scan.nil? ? :false : project.metadata.auto_scan.to_sym,
-          members:       get_project_member_names(project.project_id),
-          member_groups: get_project_member_group_names(project.project_id),
-          provider:      :swagger,
-        )
+  end
+
+  def self.get_all_projects
+    projects = []
+    page = 1
+    begin
+      page_projects = get_projects_with_opts({:page => page})
+      projects += page_projects
+      page += 1
+    end until page_projects.empty?
+    projects
+  end
+
+  def self.get_projects_with_opts(opts)
+    api_instance = do_login
+    begin
+      if api_instance[:api_version] == 2
+        projects = api_instance[:client].list_projects(opts)
+        projects.nil? ? [] : projects
+      else
+        projects = api_instance[:client].projects_get(opts)
+        projects.nil? ? [] : projects
       end
     end
   end
@@ -109,6 +124,10 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
       if (resource = resources[int.name])
         resource.provider = int
       end
+    rescue Harbor2Client::ApiError => e
+      puts "Exception when calling ProjectApi->list_projects: #{e}"
+    rescue Harbor1Client::ApiError => e
+      puts "Exception when calling ProductsApi->projects_get: #{e}"
     end
   end
 
@@ -134,20 +153,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def get_projects_with_opts(opts)
-    api_instance = self.class.do_login
-    begin
-      if api_instance[:api_version] == 2
-        projects = api_instance[:client].list_projects(opts)
-        projects.nil? ? [] : projects
-      else
-        projects = api_instance[:client].projects_get(opts)
-        projects.nil? ? [] : projects
-      end
-    rescue Harbor2Client::ApiError => e
-      puts "Exception when calling ProjectApi->list_projects: #{e}"
-    rescue Harbor1Client::ApiError => e
-      puts "Exception when calling ProductsApi->projects_get: #{e}"
-    end
+    self.class.get_projects_with_opts(opts)
   end
 
   def create


### PR DESCRIPTION
At default the swagger client will only fetch 10 projects per page. If there are more projects the creation of corresponding resources are missing which results in a reconfiguration (corrective) in Puppet run.
The request to get projects was reworked to fetch additional pages as long as they provide projects.